### PR TITLE
Update README.md

### DIFF
--- a/project/README.md
+++ b/project/README.md
@@ -75,8 +75,8 @@ You can download version 0 of the dataset at:
 
 You should download the training set and place it in a directory called `coronavirus_headlines` with the following commands:
 ```
-$ mkdir coronavirus_headlines
-$ cd coronavirus_headlines
+$ mkdir coronavirus-headlines
+$ cd coronavirus-headlines
 $ wget https://izbicki.me/public/cs/cs181/coronavirus-headlines-train.jsonl.gz
 ```
 


### PR DESCRIPTION
`coronavirus-headlines` instead of `coronavirus_headlines`

an error may occur for `coronavirus_headlines`:
```
Traceback (most recent call last):
  File "names.py", line 146, in <module>
    with gzip.open(args.data,'rt') as f:
  File "//anaconda3/lib/python3.7/gzip.py", line 53, in open
    binary_file = GzipFile(filename, gz_mode, compresslevel)
  File "//anaconda3/lib/python3.7/gzip.py", line 163, in __init__
    fileobj = self.myfileobj = builtins.open(filename, mode or 'rb')
FileNotFoundError: [Errno 2] No such file or directory: 'coronavirus-headlines/coronavirus-headlines-train.jsonl.gz'
```